### PR TITLE
Fix the overflow bug of the wrap_int function

### DIFF
--- a/src/inquirer.h
+++ b/src/inquirer.h
@@ -321,13 +321,13 @@ private:
 		return (*p == 0);
 	}
 
-	static unsigned wrap_int(unsigned int k, const unsigned lowerBound, const unsigned upperBound)
+	static int wrap_int(int k, const int lowerBound, const int upperBound)
 	{
-		const unsigned range_size = upperBound - lowerBound + 1;
-
+		const int range_size = upperBound - lowerBound + 1;
+		
 		if (k < lowerBound)
 			k += range_size * ((lowerBound - k) / range_size + 1);
-
+		
 		return lowerBound + (k - lowerBound) % range_size;
 	}
 


### PR DESCRIPTION
In previous versions, the `wrap_int` function incorrectly used `unsigned` as the parameter and return type. This caused selection-type prompts to fail to correctly jump to the last option when moving up from the first option (option 0), because `k` would be `-1` at that moment, but the parameter was of an unsigned type. The type has now been corrected, and the bug has been fixed.

Previous version:

![Prev](https://github.com/user-attachments/assets/5adfd309-a187-49c9-94f6-f37ca7236bbe)

Fixed version:

![After](https://github.com/user-attachments/assets/9c0151fc-11d6-4337-bd5c-1111b425ad93)

